### PR TITLE
Keychain: Initial review refactoring

### DIFF
--- a/Sources/FTPropertyWrappers/GenericPassword.swift
+++ b/Sources/FTPropertyWrappers/GenericPassword.swift
@@ -78,7 +78,7 @@ open class GenericPassword<T: Codable>: KeychainItemPropertyWrapper<T> {
         account: String? = nil,
         refreshPolicy: KeychainDataRefreshPolicy = .onAccess,
         defaultValue: T? = nil,
-        protection: (access: AccesibleOption, flags: SecAccessControlCreateFlags)? = nil
+        protection: (access: CFString, flags: SecAccessControlCreateFlags)? = nil
     ) throws {
         self.init(service: service, account: account, refreshPolicy: refreshPolicy, defaultValue: defaultValue)
         if let protection = protection {
@@ -97,10 +97,10 @@ open class GenericPassword<T: Codable>: KeychainItemPropertyWrapper<T> {
     ///   attribute may have been set before.
     ///   - flags: Access control flags, for more information visit Keychain documentation, since this argument
     ///   is used as-is.
-    public func modifyAccess(using accessible: AccesibleOption, flags: SecAccessControlCreateFlags) throws {
+    public func modifyAccess(using accessible: CFString, flags: SecAccessControlCreateFlags) throws {
         var error: Unmanaged<CFError>?
 
-        let access = SecAccessControlCreateWithFlags(nil, accessible.rawValue, flags, &error)
+        let access = SecAccessControlCreateWithFlags(nil, accessible, flags, &error)
         if let error = error?.takeRetainedValue() as Error? {
             throw KeychainError.accessControllError(status: error)
         }

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainDecoder.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainDecoder.swift
@@ -46,10 +46,6 @@ struct KeychainDecoder {
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(codingPath: [], debugDescription: "Decoding root type Float not supported!", underlyingError: nil)
             )
-        case is Float80.Type:
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(codingPath: [], debugDescription: "Decoding root type Float80 not supported!", underlyingError: nil)
-            )
         case is Double.Type:
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(codingPath: [], debugDescription: "Decoding root type Double not supported!", underlyingError: nil)

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainEncoder.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainEncoder.swift
@@ -48,10 +48,6 @@ struct KeychainEncoder {
             throw EncodingError.invalidValue( value,
                 EncodingError.Context(codingPath: [], debugDescription: "Encoding root type Float not supported!", underlyingError: nil)
             )
-        case is Float80.Type:
-            throw EncodingError.invalidValue( value,
-                EncodingError.Context(codingPath: [], debugDescription: "Encoding root type Float80 not supported!", underlyingError: nil)
-            )
         case is Double.Type:
             throw EncodingError.invalidValue( value,
                 EncodingError.Context(codingPath: [], debugDescription: "Encoding root type Double not supported!", underlyingError: nil)

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainItemPropertyWrapper.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainItemPropertyWrapper.swift
@@ -108,7 +108,7 @@ open class KeychainItemPropertyWrapper<T: Codable>: SingleValueKeychainItem {
     open func loadFromKeychain() throws {
         resetQueryElementsExcludedKeys()
         do {
-            if let decoded = try (try executeFetchQuery()).flatMap({ try self.decoder.decode(T.self, from: $0)}) {
+            if let decoded = try executeFetchQuery().flatMap({ try self.decoder.decode(T.self, from: $0)}) {
                 cachedValue = decoded
             } else {
                 throw KeychainError.loadSucceededWithoutData

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainItemPropertyWrapper.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainItemPropertyWrapper.swift
@@ -73,35 +73,6 @@ open class KeychainItemPropertyWrapper<T: Codable>: SingleValueKeychainItem {
         }
     }
 
-    /// Requirred override. This class has to ensure, that cached value is not nil, when method triggering read or
-    /// write of this property is called.
-    /// - Note:
-    /// *Future proposition*: Remove itemData property and modify triggering methods to accept data as
-    /// argument and returining as return value.
-    override open var itemData: Data {
-        get {
-            guard let cachedValue = cachedValue else {
-                print("FTPropertyWrappers KeychainItemPropertyWrapper: error: invalid calling convention, cached value is nil")
-                return Data()
-            }
-            do {
-                return try encoder.encode(cachedValue)
-            } catch {
-                print("FTPropertyWrappers KeychainItemPropertyWrapper encoding: error: \(error)")
-                return Data()
-            }
-        }
-        set {
-            do {
-                cachedValue = try decoder.decode(T.self, from: newValue)
-            } catch {
-                print("FTPropertyWrappers KeychainItemPropertyWrapper decoding: error: \(error)")
-                cachedValue = nil
-            }
-
-        }
-    }
-
     /// Creates instance in order to configure read only properties. This class should not be instantiated, since it
     /// does not override all requirred properties.
     /// - Parameters:
@@ -117,15 +88,15 @@ open class KeychainItemPropertyWrapper<T: Codable>: SingleValueKeychainItem {
     /// If not, insert operation is executed. In case, that such an item is already in keychain
     /// (`osSecureDuplicitItem` error is thrown), update query is executed.
     open func saveToKeychain() throws {
-        guard cachedValue != nil else {
+        guard let cachedValue = cachedValue else {
             try deleteKeychain()
             return
         }
 
         do {
-            try executeInsertQuery()
+            try executeInsertQuery(storing: try encoder.encode(cachedValue))
         } catch KeychainError.osSecureDuplicitItem {
-            try executeUpdateQuery()
+            try executeUpdateQuery(storing: try encoder.encode(cachedValue))
         }
 
         wrappedValueUnchanged = true
@@ -137,7 +108,11 @@ open class KeychainItemPropertyWrapper<T: Codable>: SingleValueKeychainItem {
     open func loadFromKeychain() throws {
         resetQueryElementsExcludedKeys()
         do {
-            try executeFetchQuery()
+            if let decoded = try (try executeFetchQuery()).flatMap({ try self.decoder.decode(T.self, from: $0)}) {
+                cachedValue = decoded
+            } else {
+                throw KeychainError.loadSucceededWithoutData
+            }
         } catch KeychainError.osSecureNoSuchItem {
             cachedValue = nil
         }

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainTypes.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainTypes.swift
@@ -127,7 +127,10 @@ public enum KeychainDataRefreshPolicy {
 
 /// `KeychainError` encapsulates common errors throws by enclosed services.
 public enum KeychainError: Error {
-    case unexpectedFormat, generalEncodingFailure, generalDecodingFailure
+    case unexpectedFormat
+    case generalEncodingFailure
+    case generalDecodingFailure
+    case loadSucceededWithoutData
     case accessControllErrorUnknown
     case accessControllError(status: Error)
     case osSecure(status: OSStatus)

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainTypes.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainTypes.swift
@@ -62,8 +62,10 @@ public enum KeychainQueryPresenceConstraint {
 /// are resolved.
 public final class QueryElement<T>: WrappedConfiguringElement {
 
-    /// Value corresponding to the attribute key. *Notice: when a value of corresponding key is alredy present in
-    /// the keychain, setting wrapped value to nil will not unset this attribute in keychain.*
+    /// Value corresponding to the attribute key.
+    /// - Note:
+    /// When a value of corresponding key is alredy present in he keychain, setting wrapped value to nil will not
+    /// unset this attribute in keychain.
     public var wrappedValue: T?
 
     /// kSecAttr**** key at keychain query.
@@ -84,8 +86,9 @@ public final class QueryElement<T>: WrappedConfiguringElement {
     }
 
     /// Creates regular query element. Elements created with this initializer are written to queries and parsed from
-    /// responses. *Notice: when a value of corresponding key is alredy present in the keychain, setting wrapped
-    /// value to nil will not unset this attribute in keychain.*
+    /// responses.
+    /// - Note: When a value of corresponding key is alredy present in the keychain, setting wrapped value to
+    /// nil will not unset this attribute in keychain.
     /// - Parameters:
     ///   - key: Corresponding kSecAttr**** key at keychain query.
     ///   - constraints: Constraints are result of conditions described in Apple's documentation.

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainTypes.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainTypes.swift
@@ -163,35 +163,3 @@ public enum KeychainError: Error {
         }
     }
 }
-
-/// `AccesibleOption` encapsulates all constants for attribute kSecAttrAccessible, that are present in current
-/// OS versions.
-public enum AccesibleOption: CaseIterable {
-    case whenPasswordSetThisDeviceOnly
-    case whenUnlockedThisDeviceOnly
-    case whenUnlocked
-    case afterFirstUnlockThisDeviceOnly
-    case afterFirstUnlock
-
-    public var rawValue: CFString {
-        switch self {
-        case .whenPasswordSetThisDeviceOnly:
-            return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
-        case .whenUnlockedThisDeviceOnly:
-            return kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-        case .whenUnlocked:
-            return kSecAttrAccessibleWhenUnlocked
-        case .afterFirstUnlockThisDeviceOnly:
-            return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        case .afterFirstUnlock:
-            return kSecAttrAccessibleAfterFirstUnlock
-        }
-    }
-
-    public init?(rawValue: CFString) {
-        guard let value = AccesibleOption.allCases.first(where: { rawValue == $0.rawValue }) else {
-            return nil
-        }
-        self = value
-    }
-}

--- a/Sources/FTPropertyWrappers/Keychain - Support/SingleValueKeychainItem.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/SingleValueKeychainItem.swift
@@ -67,16 +67,11 @@ open class SingleValueKeychainItem {
     /// Delete the item from keychain in order to reset this attribute.
     @QueryElement(key: kSecAttrIsInvisible) open var isInvisible: Bool?
 
-
     /// `QueryElement` accessible specifies conditions for accessing this item.
     /// - Note:
     /// Once corresponding value stored in keychain, setting this property to `nil` will not have any effect.
     /// Delete the item from keychain in order to reset this attribute.
-    open var accesible: AccesibleOption? {
-        get { _raw_accesible.flatMap(AccesibleOption.init(rawValue:)) }
-        set { _raw_accesible = newValue?.rawValue }
-    }
-    @QueryElement(key: kSecAttrAccessible) private var _raw_accesible: CFString?
+    @QueryElement(key: kSecAttrAccessible) open var accesible: CFString?
 
     /// Read only `QueryElement` creation date.
     /// - Note:


### PR DESCRIPTION
This pull request contains following updates:

**Documentation commit**
Commit updating documentation which was intended to be pushed as a result of review.

**Access Control as a default value**
Access Control proven to be awkward in use. If user wanted to maintain Access Control set, it was required to modify access control before each save operation manually. `.onAccess` modifier was useless and broken with Access Control. Proposed solution has desired functionality but comments are appreciated.

**Float80 removed**
Float80 was removed, because it was strictly x86 type.

**ItemData removed**
Item data was removed and it's functionality was replaced by passing values through method calls. This may move implementation in more Swift direction, since "abstract class" pattern in not present in Swift and a lot of more issues are now possible to throw as an error instead of printing string.

**Accessible enum was removed**
Accessible enum which encapsulated possible values of kSecAttrAccessible in type and value safe manner was removed and replaced by plain CFString value. This was done due to fact, that possible values differ on platforms and possible values undergone updates in recent past. 
Another reason is consistency with the rest of this property wrapper, since other "closed" value attributes like kSecAttrProtocol didn't have its respective enum and maintaining all such enums would be futile without significant value for the programmer.