### PR TITLE
Housekeeep: Increase iOS development target to 9.0

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,14 +8,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install and run SwiftLint
+    - name: Run SwiftLint
       run: |
-        brew install swiftlint
         swiftlint
-    - name: Lint pod lib
+    - name: Pod lib lint
       run: |
         gem install cocoapods
-        pod lib lint
+        pod lib lint --allow-warnings
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/FTPropertyWrappers.podspec
+++ b/FTPropertyWrappers.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author             = { "Mikoláš Stuchlík" => "mikolas.stuchlik@futured.app" }
   s.social_media_url   = "https://twitter.com/FuturedApps"
   s.swift_version = "5.1"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"

--- a/FTPropertyWrappers.podspec
+++ b/FTPropertyWrappers.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FTPropertyWrappers"
-  s.version      = "1.0.0"
+  s.version      = "1.1.0"
   s.summary      = "Commonly used property wrappers"
   s.description  = <<-DESC
     Property wrappers for common use-cases such as User Defaults, Serialization,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Futured apps s.r.o.
+Copyright (c) 2021 Futured apps s.r.o.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,6 @@ let package = Package(
             name: "FTPropertyWrappers",
             targets: ["FTPropertyWrappers"])
     ],
-    dependencies: [],
     targets: [
         .target(
             name: "FTPropertyWrappers",

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainDecoder.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainDecoder.swift
@@ -7,7 +7,7 @@ struct KeychainDecoder {
     /// Property list decoder is used for decoding if type `T` has no explicit decoding method.
     private let decoder: PropertyListDecoder = PropertyListDecoder()
 
-    //swiftlint:disable force_cast
+    // swiftlint:disable force_cast
     /// Decode type `T` from provided `Data`. This method uses different method for each `T` which could be
     /// considered as a "single value". Collection and other `Decodable` types are decoded using
     /// `PropertyListDecoder`.
@@ -21,7 +21,7 @@ struct KeychainDecoder {
     /// - Parameters:
     ///   - type: Type used for inferring decodation strategy and return type.
     ///   - data: Binary data to decode.
-    //swiftlint:disable:next function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         switch type {
         case let type as Int.Type:
@@ -68,7 +68,7 @@ struct KeychainDecoder {
             return try decoder.decode(T.self, from: data)
         }
     }
-    //swiftlint:enable force_cast
+    // swiftlint:enable force_cast
 
     private func decode(_ type: Int.Type, from data: Data) throws -> Int {
         switch data.count {

--- a/Sources/FTPropertyWrappers/Keychain - Support/KeychainEncoder.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/KeychainEncoder.swift
@@ -22,7 +22,7 @@ struct KeychainEncoder {
     /// *Calling convention*: if this method is called with type `Data` as a generic type T, this method should
     /// return the argument as-is without any changes.
     /// - Parameter value: Value to be encoded.
-    //swiftlint:disable:next function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     func encode<T: Encodable>(_ value: T) throws -> Data {
         switch value {
         case let value as Int:

--- a/Sources/FTPropertyWrappers/Keychain - Support/SingleValueKeychainItem.swift
+++ b/Sources/FTPropertyWrappers/Keychain - Support/SingleValueKeychainItem.swift
@@ -206,7 +206,7 @@ open class SingleValueKeychainItem {
         }
     }
 
-    //swiftlint:disable:next line_length
+    // swiftlint:disable:next line_length
     // https://developer.apple.com/documentation/security/keychain_services/keychain_items/adding_a_password_to_the_keychain
     /// Executes insert query.
     func executeInsertQuery(storing data: Data) throws {
@@ -233,7 +233,7 @@ open class SingleValueKeychainItem {
         return configure(from: response)
     }
 
-    //swiftlint:disable:next line_length
+    // swiftlint:disable:next line_length
     // https://developer.apple.com/documentation/security/keychain_services/keychain_items/updating_and_deleting_keychain_items
     /// Exected update query.
     func executeUpdateQuery(storing data: Data) throws {
@@ -246,7 +246,7 @@ open class SingleValueKeychainItem {
         }
     }
 
-    //swiftlint:disable:next line_length
+    // swiftlint:disable:next line_length
     // https://developer.apple.com/documentation/security/keychain_services/keychain_items/updating_and_deleting_keychain_items
     /// Executes delete query.
     func executeDeleteQuery() throws {

--- a/Tests/FTPropertyWrappersTests/KeychainTests.swift
+++ b/Tests/FTPropertyWrappersTests/KeychainTests.swift
@@ -1,4 +1,4 @@
-//swiftlint:disable line_length function_body_length force_try type_body_length
+// swiftlint:disable line_length function_body_length force_try type_body_length
 
 import XCTest
 @testable import FTPropertyWrappers
@@ -366,4 +366,4 @@ final class KeychainTests: XCTestCase {
     ]
 }
 
-//swiftlint:enable line_length function_body_length force_try type_body_length
+// swiftlint:enable line_length function_body_length force_try type_body_length


### PR DESCRIPTION
Xcode od verze 12 podporuje zařízení s iOS 9 a výše.

> The Xcode 12 release supports on-device debugging for iOS 9 and later
https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes